### PR TITLE
Add link to developer docs and placeholder commands for TODO sections.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,16 +25,34 @@ only daemon that can be controlled by the AS is nginx ([website](https://nginx.o
 ## Downloading
 
 _TODO_
+```
+git clone --recurse-submodules https://github.com/5G-MAG/rt-5gms-application-server.git
+```
 
 ## Building
 
 _TODO_
+```
+cd rt-5gms-application-server
+python3 -m build --sdist
+```
 
 ## Installing
 
 _TODO_
+```
+cd rt-5gms-application-server
+pip install -e .
+```
 
 ## Running
 
 _TODO_
+```
+5gms-application-server <ContentHostingConfiguration-JSON-file>
+```
 
+## Development
+
+Please see the [docs/README.md](docs/README.md) file for project development
+and testing information.


### PR DESCRIPTION
On the developers call on Friday 30th September 2022 a link from the main project README to the development documentation was requested.

I've added a link along with some placeholder example commands for the other sections marked as TODO in the main project README.