### PR TITLE
Add an application configuration file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include build_scripts

--- a/docs/example-application-server.conf
+++ b/docs/example-application-server.conf
@@ -1,0 +1,146 @@
+#############################################################################
+# 5G-MAG Reference Tools: 5GMS application server example configuration file
+#############################################################################
+# Author: David Waring <david.waring2@bbc.co.uk>
+# License: 5G-MAG Public Licence v1.0
+# Copyright: © 2022 British Broadcasting Corporation
+#
+# For full license terms please see the LICENSE file distributed with this
+# program. If this file is missing then the license can be retrieved from
+# https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+#############################################################################
+#
+# This is an example configuration file for the 5G-MAG Reference Tools 5GMS
+# Application Server. This file contains a description of the configuration
+# settings available and their default values.
+#
+
+### Defaults for the 5G-MAG Reference Tools: 5GMS applications
+[DEFAULT]
+#log_dir = /var/log/rt-5gms
+#run_dir = /run/rt-5gms
+
+
+
+### 5GMS Application Server specific configurations
+[5gms_as]
+# cache_dir - The directory to hold cached objects in
+#
+# The actual format of files and subdirectories within this directory is
+# dependant on the web proxy/server chosen at run-time.
+#
+# If this setting is empty or omitted then the web proxy/server will run
+# without a disk cache.
+#
+# For the nginx web proxy it is advisable to locate this directory on the same
+# filesystem partition as the temporary directories to make moving objects from
+# temporary stores to the disk cache more efficient.
+#
+# Default is /var/cache/rt-5gms/as/cache
+#cache_dir = /var/cache/rt-5gms/as/cache
+
+# http_port - The TCP port number to listen for HTTP requests on
+#
+# This determines which port the web proxy/server will bind to for distribution
+# configurations without a security certificate.
+#
+# The default is port 80
+#http_port = 80
+
+# https_port - The TCP port number to listen for TLS based HTTP requests on
+#
+# This determines which port the web proxy/server will bind to for distribution
+# configurations with an associated security certificate.
+#
+# The default port is 443
+#https_port = 443
+
+# access_log - The location to write the web proxy/server access log.
+#
+# This is the path to the file to log access requests in.
+#
+# The default is /var/log/rt-5gms/application-server-access.log
+#access_log = %(log_dir)s/application-server-access.log
+
+# error_log - The location to write the web proxy/server access log.
+#
+# This is the path to the file to log access requests in.
+#
+# The default is /var/log/rt-5gms/application-server-error.log
+#error_log = %(log_dir)s/application-server-error.log
+
+# pid_path - Path for the process identifier for the 5gms application server
+#
+# The top level process id will be written to this file.
+#
+# The default is /run/rt-5gms/application-server.pid
+#pid_path = %(run_dir)s/application-server.pid
+
+
+
+### 5GMS Application Server nginx specific configuration
+[5gms_as.nginx]
+# root_temp - variable to hold the top level temporary store directory
+#root_temp = /var/cache/rt-5gms/as
+
+# client_body_temp - Temporary disk store for client request body contents
+#
+# nginx temporary storage area for client request body contents. This must be
+# specified as a valid directory and cannot be empty.
+#
+# See: https://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_temp_path
+#
+# Default is /tmp/rt-5gms-as/client-body-tmp
+#client_body_temp = %(root_temp)s/client-body-tmp
+
+# proxy_temp - Temporary disk store for proxied responses
+#
+# nginx temporary storage area for proxied response body contents. This must be
+# specified as a valid directory and cannot be empty.
+#
+# It is advisable to place this directory on the same filesystem partition as
+# the main cache directories (see 5gms_as.cache_dir above).
+#
+# See: https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_temp_path
+#
+# Default is /tmp/rt-5gms-as/proxy-tmp
+#proxy_temp = %(root_temp)s/proxy-tmp
+
+# fastcgi_temp - Temporary disk store for fastcgi server responses
+#
+# nginx storage area for responses from a backend fastcgi server. This must be
+# specified as a valid directory and cannot be empty.
+#
+# See: https://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_temp_path
+#
+# Default is /tmp/rt-5gms-as/fastcgi-tmp
+#fastcgi_temp = %(root_temp)s/fastcgi-tmp
+
+# uwsgi_temp - Temporary disk store for uwsgi server responses
+#
+# nginx storage area for responses from a backend uwsgi server. This must be
+# specified as a valid directory and cannot be empty.
+#
+# See: https://nginx.org/en/docs/http/ngx_http_uwsgi_module.html#uwsgi_temp_path
+#
+# Default is /tmp/rt-5gms-as/uwsgi-tmp
+#uwsgi_temp = %(root_temp)s/uwsgi-tmp
+
+# scgi_temp - Temporary disk store for SCGI server responses
+#
+# nginx storage area for responses from a backend SCGI server. This must be
+# specified as a valid directory and cannot be empty.
+#
+# See: https://nginx.org/en/docs/http/ngx_http_scgi_module.html#scgi_temp_path
+#
+# Default is /tmp/rt-5gms-as/scgi-tmp
+#scgi_temp = %(root_temp)s/scgi-tmp
+
+# pid_path - File location to store the PID of the nginx process
+#
+# The nginx daemon will store the pid of its process in this file.
+#
+# See: https://nginx.org/en/docs/ngx_core_module.html#pid
+#
+# Default is /tmp/rt-5gms-as/5gms-as-nginx.pid
+#pid_path = %(root_temp)s/5gms-as-nginx.pid

--- a/src/rt_5gms_as/app.py
+++ b/src/rt_5gms_as/app.py
@@ -35,13 +35,19 @@ def get_arg_parser():
 
     Syntax:
       rt-5gsm-as -h
-      rt-5gsm-as <config-file>
+      rt-5gsm-as [-c <app-config-file>] <content-config-file>
 
     Options:
-      -h    Show the help text
+      -h         --help           Show the help text
+      -c CONFIG  --config CONFIG  The application configuration file
+
+    Parameters:
+      content-config-file  This the file name of a file containing a
+                           ContentHostingConfiguration in JSON format.
     '''
     parser = argparse.ArgumentParser()
-    parser.add_argument('config', metavar='CHC-JSON-FILE', help='The ContentHostingConfiguration JSON file')
+    parser.add_argument('-c', '--config', nargs=1, required=False, metavar='CONFIG', help='The application configuration file')
+    parser.add_argument('contentconfig', nargs=1, metavar='CHC-JSON-FILE', help='The ContentHostingConfiguration JSON file')
     return parser
 
 def list_join(l, sep1, sep2=None):
@@ -80,7 +86,13 @@ def main():
         log.error("Please install at least one of: %s", list_join([p.name() for p in list_registered_web_proxies()], ', ', ' or '))
         return 1
 
-    context = Context(args.config)
+    config = args.config
+    if config is not None:
+        config = config[0]
+    contentconfig = args.contentconfig
+    if contentconfig is not None:
+        contentconfig = contentconfig[0]
+    context = Context(config, contentconfig)
     proxy = WebProxy(context)
 
     if not proxy.writeConfiguration():

--- a/src/rt_5gms_as/context.py
+++ b/src/rt_5gms_as/context.py
@@ -24,10 +24,36 @@ This module provides a single Context class which holds the context for the
 5G-MAG Reference Tools 5GMS AS Network Function.
 '''
 
+import configparser
 import json
+import os
+import os.path
 
 from .openapi_5g.model.content_hosting_configuration import ContentHostingConfiguration
 from .openapi_5g.model_utils import deserialize_model
+
+DEFAULT_CONFIG = '''[DEFAULT]
+log_dir = /var/log/rt-5gms
+run_dir = /run/rt-5gms
+
+[5gms_as]
+cache_dir = /var/cache/rt-5gms/as/cache
+http_port = 80
+https_port = 443
+listen_address = ::
+access_log = %(log_dir)s/application-server-access.log
+error_log = %(log_dir)s/application-server-error.log
+pid_path = %(run_dir)s/application-server.pid
+
+[5gms_as.nginx]
+root_temp = /var/cache/rt-5gms/as
+client_body_temp = %(root_temp)s/client-body-tmp
+proxy_temp = %(root_temp)s/proxy-tmp
+fastcgi_temp = %(root_temp)s/fastcgi-tmp
+uwsgi_temp = %(root_temp)s/uwsgi-tmp
+scgi_temp = %(root_temp)s/scgi-tmp
+pid_path = %(root_temp)s/rt-5gms-as-nginx.pid
+'''
 
 class Context(object):
     '''
@@ -38,13 +64,29 @@ class Context(object):
     Tools 5GMS AS Network Function.
     '''
 
-    def __init__(self, config_filename):
+    def __init__(self, config_filename, content_hosting_config):
         '''Constructor
 
-        config_filename (str) - filename of the ContentHostingConfiguration JSON
+        config_filename (str)        - filename of the application configuration
+        content_hosting_config (str) - filename of the ContentHostingConfiguration JSON
         '''
-        chc = deserialize_model(json.load(open(config_filename, 'r')), ContentHostingConfiguration, config_filename, True, {}, True)
+        if config_filename is None:
+            config_filename = self.__find_config_file()
+        self.__config = configparser.ConfigParser()
+        self.__config.read_string(DEFAULT_CONFIG)
+        if config_filename is not None:
+            self.__config.read(config_filename)
+        chc = deserialize_model(json.load(open(content_hosting_config, 'r')), ContentHostingConfiguration, config_filename, True, {}, True)
         self.__chcs = {chc.name: chc}
+        # ensure configured directories exist
+        for directory in [
+            self.__config.get('5gms_as', 'cache_dir'),
+            os.path.dirname(self.__config.get('5gms_as', 'access_log')),
+            os.path.dirname(self.__config.get('5gms_as', 'error_log')),
+            os.path.dirname(self.__config.get('5gms_as', 'pid_path')),
+            ]:
+            if directory is not None and len(directory) > 0 and not os.path.isdir(directory):
+                os.makedirs(directory)
 
     def contentHostingConfigurations(self):
         '''Get the list of defined ContentHostingConfiguration objects
@@ -65,3 +107,15 @@ class Context(object):
             return self.__chcs[name]
         return None
 
+    def getConfigVar(self, section, varname, default=None):
+        return self.__config.get(section, varname, fallback=default)
+
+    def __find_config_file(self):
+        cfgs = []
+        if os.getuid() != 0:
+            cfgs += [os.path.expanduser(os.path.join('~', '.rt-5gms', 'application-server.conf'))]
+        cfgs += [os.path.join(os.path.sep, 'etc', 'rt-5gms', 'application-server.conf')]
+        for cfgfile in cfgs:
+            if os.path.exists(cfgfile):
+                return cfgfile
+        return None

--- a/src/rt_5gms_as/proxies/nginx-server.conf.tmpl
+++ b/src/rt_5gms_as/proxies/nginx-server.conf.tmpl
@@ -1,7 +1,9 @@
   server {{
-    listen	8080;
-    listen      [::]:8080;
+    listen	{http_port};
+    listen      [::]:{http_port};
     server_name {server_names};
+
+    {proxy_cache_directive}
 
     location / {{
       return 404;

--- a/src/rt_5gms_as/proxies/nginx.conf.tmpl
+++ b/src/rt_5gms_as/proxies/nginx.conf.tmpl
@@ -1,3 +1,19 @@
+#############################################################################
+# 5G-MAG Reference Tools: 5GMS Application Server - nginx configuration
+#############################################################################
+# Author: David Waring <david.waring2@bbc.co.uk>
+# License: 5G-MAG Public Licence v1.0
+# Copyright: © 2022 British Broadcasting Corporation
+#
+# For full license terms please see the LICENSE file distributed with this
+# program. If this file is missing then the license can be retrieved from
+# https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+#############################################################################
+#
+# This file is generated from templates, do not edit manually as it will
+# likely get replaced by the 5GMS application server.
+#
+
 worker_processes 5;
 error_log	{error_log_path};
 pid		{pid_path};
@@ -22,7 +38,7 @@ http {{
   types_hash_max_size 4096;
   client_body_temp_path {client_body_tmp};
   proxy_temp_path {proxy_temp_path};
-  proxy_cache_path {proxy_cache_path} levels=1:2 use_temp_path=on keys_zone=one:10m;
+  {proxy_cache_path_directive}
   fastcgi_temp_path {fastcgi_temp_path};
   uwsgi_temp_path {uwsgi_temp_path};
   scgi_temp_path {scgi_temp_path};
@@ -34,16 +50,16 @@ http {{
 
 {server_configs}
 
-#  server {{
-#    listen       8080 default_server;
-#    listen       [::]:8080 default_server;
-#    server_name  _;
-#    root         /usr/share/nginx/html;
-#    error_page 404 /404.html;
-#    location = /404.html {{
-#    }}
-#    error_page 500 502 503 504 /50x.html;
-#    location = /50x.html {{
-#    }}
-#  }}
+  server {{
+    listen       {http_port} default_server;
+    listen       [::]:{http_port} default_server;
+    server_name  _;
+    root         /usr/share/nginx/html;
+    error_page 404 /404.html;
+    location = /404.html {{
+    }}
+    error_page 500 502 503 504 /50x.html;
+    location = /50x.html {{
+    }}
+  }}
 }}


### PR DESCRIPTION
Fixes 5G-MAG/rt-5gms-application-server#5

Adds an application configuration file (example in docs/example-application-server.conf) which contains the directory to place the cache into (default: /var/cache/rt-5gms/as/cache). If set to the empty string will disable caching. This configuration also allows the HTTP and HTTPS listening port numbers to be set in the configuration to aid in development (i.e. http_port and https_port can be set above 1024 for running as a normal user). The configuration also provides a section for nginx specific configuration values and so provides a template for adding configuration for other backend web servers/proxies.