### PR TITLE
Validate ContentHostingConfiguration rewriteRule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ name = "rt-5gms-application-server"
 version = "0.0.1"
 dependencies = [
     'urllib3 >= 1.25.3',
-    'python-dateutil'
+    'python-dateutil',
+    'regex >= 2.5.0'
 ]
 requires-python = ">=3.7"
 scripts = { 5gms-application-server = "rt_5gms_as.app:main" }


### PR DESCRIPTION
Fixes 5G-MAG/rt-5gms-application-server#10

Adds some code to validate the regex passed in the pathRewriteRule.request_pattern. This uses the PyPi "regex" module to check the syntax of the regular expression and counts how many subexpressions causing back-references there are.

The regex module implements Perl style regex syntax, which is the same used for nginx. TS 26.512 table 7.6.3.1-1 states that the regular expression in the request_pattern field is in ECMA-262 (v5.1, Jun 2011) RegExp syntax. ECMA RegExp appears to have the same syntax and semantics as a subset of Perl regular expressions and this is why we can use the regex module to perform the checks.