### PR TITLE
Update docs and configuration to add provisioning-session-id UUID.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -35,13 +35,36 @@ cd rt-5gms-application-server
 build_scripts/generate_openapi
 ```
 
+Create a configuration to run the application server as a local, unprivileged,
+user.
+```
+mkdir ~/.rt_5gms
+cat > ~/.rt_5gms/application-server.conf <<EOF
+[DEFAULT]
+log_dir = /tmp/rt-5gms-as/logs
+run_dir = /tmp/rt-5gms-as
+
+### 5GMS Application Server specific configurations
+[5gms_as]
+cache_dir = /tmp/rt-5gms-as/cache
+http_port = 8080
+https_port = 8443
+
+### 5GMS Application Server nginx specific configuration
+[5gms_as.nginx]
+root_temp = /tmp/rt-5gms-as
+EOF
+mkdir -p /tmp/rt-5gms-as/cache
+mkdir /tmp/rt-5gms-as/logs
+```
+
 Run the example directly:
 ```
 cd rt-5gms-application-server/src
 python3 -m rt_5gms_as.app ../docs/rt-common-shared/5gms/examples/ContentHostingConfiguration_Big-Buck-Bunny_pull-ingest.json
 ```
 
-This will start nginx with a configuration which will provide a reverse proxy to the Big Buck Bunny DASH media at <http://localhost:8080/m4d/provisioning-session-1234abcd/BigBuckBunny_4s_onDemand_2014_05_09.mpd>.
+This will start nginx with a configuration which will provide a reverse proxy to the Big Buck Bunny DASH media at <http://localhost:8080/m4d/provisioning-session-d54a1fcc-d411-4e32-807b-2c60dbaeaf5f/BigBuckBunny_4s_onDemand_2014_05_09.mpd>.
 
 Regenerating the 5G API bindings
 --------------------------------

--- a/docs/example-application-server.conf
+++ b/docs/example-application-server.conf
@@ -76,6 +76,22 @@
 # The default is /run/rt-5gms/application-server.pid
 #pid_path = %(run_dir)s/application-server.pid
 
+# provisioning_session_id - Provisioning session for this application server
+#
+# This is the provisioning session identifier for this application server (AS)
+# instance. This is the session ID as allocated to the application provider
+# (AP) by the application function (AF) during the ProvisioningSessions.
+#
+# The default is d54a1fcc-d411-4e32-807b-2c60dbaeaf5f
+#provisioning_session_id = d54a1fcc-d411-4e32-807b-2c60dbaeaf5f
+
+# m4d_path_prefix - Path prefix for the M4d interface
+#
+# This is the path prefix that will be used on all media accesses for this
+# provisioning session.
+#
+# The default is /m4d/provisioning-session-<session-id>/
+#m4d_path_prefix = /m4d/provisioning-session-%(provisioning_session_id)s/
 
 
 ### 5GMS Application Server nginx specific configuration

--- a/src/rt_5gms_as/context.py
+++ b/src/rt_5gms_as/context.py
@@ -44,6 +44,8 @@ listen_address = ::
 access_log = %(log_dir)s/application-server-access.log
 error_log = %(log_dir)s/application-server-error.log
 pid_path = %(run_dir)s/application-server.pid
+provisioning_session_id = d54a1fcc-d411-4e32-807b-2c60dbaeaf5f
+m4d_path_prefix = /m4d/provisioning-session-%(provisioning_session_id)s/
 
 [5gms_as.nginx]
 root_temp = /var/cache/rt-5gms/as

--- a/src/rt_5gms_as/proxies/nginx-server.conf.tmpl
+++ b/src/rt_5gms_as/proxies/nginx-server.conf.tmpl
@@ -9,7 +9,7 @@
       return 404;
     }}
 
-    location ~ ^/m4d/provisioning-session-{provision_session}/ {{
+    location ~ ^{m4d_path_prefix} {{
 {rewrite_rules}
       proxy_pass	{downstream_origin};
     }}

--- a/src/rt_5gms_as/proxies/nginx.py
+++ b/src/rt_5gms_as/proxies/nginx.py
@@ -103,8 +103,9 @@ class NginxWebProxy(WebProxyInterface):
         fastcgi_temp_path = self._context.getConfigVar('5gms_as.nginx','fastcgi_temp')
         uwsgi_temp_path = self._context.getConfigVar('5gms_as.nginx','uwsgi_temp')
         scgi_temp_path = self._context.getConfigVar('5gms_as.nginx','scgi_temp')
-        # provision session should come from the AF
-        provision_session='1234abcd'
+        # provisioning session should come from the AF via M3
+        provisioning_session_id = self._context.getConfigVar('5gms_as','provisioning_session_id')
+        m4d_path_prefix = self._context.getConfigVar('5gms_as','m4d_path_prefix')
         # Create caching directives if we have a cache dir configured
         proxy_cache_path_directive = ''
         proxy_cache_directive = ''


### PR DESCRIPTION
Closes 5G-MAG/rt-5gms-application-server#28

Documentation and configuration updated in line with the example ServiceAccessInformation from 5G-MAG/rt-common-shared#5. This allows the example to be used as input to the 5GMS-Aware application in order to reference media accessible via the M4d interface provided by this AS.