### PR TITLE
Only use keyword arguments for asyncio.create_task that are understood.

### DIFF
--- a/src/rt_5gms_as/app.py
+++ b/src/rt_5gms_as/app.py
@@ -30,6 +30,7 @@ import sys
 
 from .proxy_factory import WebProxy, list_registered_web_proxies
 from .context import Context
+from .utils import async_create_task
 
 def get_arg_parser():
     '''
@@ -88,7 +89,7 @@ def sighup_handler(sig, context):
     # reload configuration
     if context.reload():
         # configuration changed, reload/restart proxy
-        asyncio.create_task(context.webProxy().reload())
+        async_create_task(context.webProxy().reload(), name='Proxy-reload')
 
 def exit_handler(sig, context):
     '''Signal handler for INT/QUIT/TERM signals
@@ -130,7 +131,7 @@ async def __app(context):
         return 1
 
     # Create a task which will wait for the web proxy daemon to exit
-    wait_task = asyncio.create_task(context.webProxy().wait(), name='Proxy-monitor')
+    wait_task = async_create_task(context.webProxy().wait(), name='Proxy-monitor')
 
     # TODO: Create HTTP server to handle M2 interface and add task to main loop
     # TODO: Create HTTP server to handle M3 interface and add task to main loop
@@ -153,7 +154,7 @@ async def __app(context):
             # Daemon started ok, start waiting for the new child process to exit
             else:
                 context.appLog().info("Web proxy process exited, has been restarted")
-                wait_task = asyncio.create_task(context.webProxy().wait(), name='Proxy-monitor')
+                wait_task = async_create_task(context.webProxy().wait(), name='Proxy-monitor')
 
     # We are exiting, tidy up other tasks
     if not wait_task.done():

--- a/src/rt_5gms_as/proxy_factory.py
+++ b/src/rt_5gms_as/proxy_factory.py
@@ -49,6 +49,8 @@ import logging
 import os.path
 import time
 
+from .utils import async_create_task
+
 __web_proxies = []
 
 def add_web_proxy(cls,prio):
@@ -289,7 +291,7 @@ class WebProxyInterface(object):
         if self.__daemon['proc'] is None:
             return True
         try:
-            comm_task = asyncio.create_task(self.__daemon['proc'].communicate(), name='wait-for-web-proxy-daemon')
+            comm_task = async_create_task(self.__daemon['proc'].communicate(), name='wait-for-web-proxy-daemon')
             await asyncio.wait({comm_task}, timeout=timeout)
             self.__daemon['returncode'] = self.__daemon['proc'].returncode
             (stdout, stderr) = comm_task.result()

--- a/src/rt_5gms_as/utils.py
+++ b/src/rt_5gms_as/utils.py
@@ -21,6 +21,7 @@
 General utility functions
 '''
 
+import asyncio
 import subprocess
 
 def find_executable_on_path(cmd):
@@ -35,3 +36,7 @@ def find_executable_on_path(cmd):
         return None
     return result.stdout.decode("utf-8").strip()
 
+def async_create_task(*args, **kwargs):
+    'Wrapper for asyncio.create_task to remove unimplemented kwargs'
+    allowedkwargs = {key: value for key,value in kwargs.items() if key in asyncio.create_task.__kwdefaults__}
+    return asyncio.create_task(*args, **allowedkwargs)


### PR DESCRIPTION
Closes 5G-MAG/rt-5gms-application-server#41

Implements a version of option 3 from issue #41 which uses some introspection to determine if the `name` parameter is allowed or not and screens the keyword arguments accordingly.