### PR TITLE
Prepare a v1.0.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ daemon that can be controlled by the AS is nginx
 * [ETSI TS 126 512](https://portal.etsi.org/webapp/workprogram/Report_WorkItem.asp?WKI_ID=66919) - 5G Media Streaming (
   5GMS): Protocols (3GPP TS 26.512 version 17.1.2 Release 17)
 
+## Install dependencies
+
+```
+sudo apt install git python3-pip python3-venv
+python3 -m pip install build
+```
+
 ## Downloading
 
 Release sdist tar files can be downloaded from _TBC_.
@@ -30,6 +37,7 @@ Release sdist tar files can be downloaded from _TBC_.
 The source can be obtained by cloning the github repository.
 
 ```
+cd ~
 git clone --recurse-submodules https://github.com/5G-MAG/rt-5gms-application-server.git
 ```
 
@@ -38,8 +46,7 @@ git clone --recurse-submodules https://github.com/5G-MAG/rt-5gms-application-ser
 To build a Python sdist distribution tar do the following.
 
 ```
-git clone --recurse-submodules https://github.com/5G-MAG/rt-5gms-application-server.git
-cd rt-5gms-application-server
+cd ~/rt-5gms-application-server
 python3 -m build --sdist
 ```
 
@@ -56,8 +63,7 @@ python3 -m pip install rt-5gms-application-server-<version>.tar.gz
 Alternatively, to installing the 5GMS Application Server from the source can be done using these commands:
 
 ```
-git clone --recurse-submodules https://github.com/5G-MAG/rt-5gms-application-server.git
-cd rt-5gms-application-server
+cd ~/rt-5gms-application-server
 python3 -m pip install .
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,12 +30,15 @@ Files in this repository:
 Running the example without building
 ------------------------------------
 Make sure that git, java, wget and nginx are installed on the local system and
-can be found on the current command path (`$PATH`).
+can be found on the current command path (`$PATH`):
+```
+sudo apt install git wget nginx default-jdk python3-regex
+```
 
 Generate the OpenAPI python modules (these are not part of the source
-distribution):
+distribution). Read documentation below on "Regenerating the 5G API bindings":
 ```
-cd rt-5gms-application-server
+cd ~/rt-5gms-application-server
 build_scripts/generate_5gms_as_openapi
 ```
 
@@ -64,7 +67,7 @@ mkdir /tmp/rt-5gms-as/logs
 
 Run the example directly:
 ```
-cd rt-5gms-application-server/src
+cd ~/rt-5gms-application-server/src
 python3 -m rt_5gms_as.app ../external/rt-common-shared/5gms/examples/ContentHostingConfiguration_Big-Buck-Bunny_pull-ingest.json
 ```
 
@@ -99,7 +102,7 @@ The `build_scripts/generate_5gms_as_openapi` script will use wget, git and java 
 
 Therefore to regenerate the API bindings you first need to remove the old bindings:
 ```
-cd rt-5gms-application-server
+cd ~/rt-5gms-application-server
 rm -rf src/rt_5gms_as/openapi_5g
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ backend-path = ["build_scripts"]
 
 [project]
 name = "rt-5gms-application-server"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
     'urllib3 >= 1.25.3',
     'python-dateutil',


### PR DESCRIPTION
This release includes:
- Documentation updates already applied to the `main` branch.
- Version bump to v1.0.1

These changes will allow us to make a new release v1.0.1 on the `main` branch, making the head of `main` a release point again.