### PR TITLE
Fix: Report 422 for bad purge regex

### DIFF
--- a/src/rt_5gms_as/app.py
+++ b/src/rt_5gms_as/app.py
@@ -156,7 +156,7 @@ async def __app(context):
 
     @m3_app.exception_handler(ProblemException)
     async def problem_exception_handler(request, exc):
-        return AppJSONResponse(status_code=exc.status_code, content=exc.object, headers=exc.headers)
+        return AppJSONResponse(status_code=exc.status_code, content=exc.object, headers=exc.headers, media_type='application/problem+json')
 
     @m3_app.exception_handler(NoProblemException)
     async def no_problem_exception_handler(request, exc):

--- a/src/rt_5gms_as/exceptions.py
+++ b/src/rt_5gms_as/exceptions.py
@@ -19,10 +19,16 @@
 Reference Tools: 5GMS Application Server Exceptions
 ===================================================
 '''
-from typing import Optional
+from typing import Optional, List, TypedDict
+
+class InvalidParamMandatory(TypedDict):
+    param: str
+
+class InvalidParam(InvalidParamMandatory, total=False):
+    reason: str
 
 class ProblemException(Exception):
-    def __init__(self, status_code=500, title=None, detail=None, problem_type=None, instance=None, headers: Optional[dict] = None):
+    def __init__(self, status_code=500, title=None, detail=None, problem_type=None, instance=None, headers: Optional[dict] = None, invalid_params: Optional[List[InvalidParam]] = None):
         # defaults
         if title is None:
             title = 'Internal Server Error'
@@ -39,10 +45,13 @@ class ProblemException(Exception):
         self.problem_type = problem_type
         self.instance = instance
         self.headers = headers
+        self.invalid_params = invalid_params
         # Create Problem object
         self.object = {'title': self.title, 'detail': self.detail, 'type': self.problem_type, 'status': self.status_code}
         if self.instance is not None:
             self.object['instance'] = self.instance
+        if self.invalid_params is not None and len(self.invalid_params) > 0:
+            self.object['invalidParams'] = self.invalid_params
 
     def __str__(self):
         return '[%i] %s'%(self.status_code,self.detail)


### PR DESCRIPTION
Will return a 422 status code when the regex is malformed detailing the reported problem with the regex in the invalidParams array entry for the `'pattern'` parameter.

Test M3 client will report ProblemDetail error responses (title + description) and include invalidParams from the ProblemDetail if present.

Also reports 415 status codes when the Content-Type is not as expected when a request body is expected.

Closes 5G-MAG/rt-5gms-application-server#52.