### PR TITLE
Fix: Force access mode when creating directories.

### DIFF
--- a/src/rt_5gms_as/context.py
+++ b/src/rt_5gms_as/context.py
@@ -394,7 +394,11 @@ class Context(object):
             os.path.dirname(config.get('5gms_as', 'pid_path')),
             ]:
             if directory is not None and len(directory) > 0 and not os.path.isdir(directory):
-                os.makedirs(directory)
+                old_umask = os.umask(0)
+                try:
+                    os.makedirs(directory, mode=0o755)
+                finally:
+                    os.umake(old_umask)
         # get logging level from the configuration file
         logging_levels = {
                 'debug': logging.DEBUG,

--- a/src/rt_5gms_as/proxies/nginx.py
+++ b/src/rt_5gms_as/proxies/nginx.py
@@ -160,7 +160,11 @@ class NginxServerConfig(object):
             docroot = os.path.join(self.__context.getConfigVar('5gms_as','docroot'), master_host)
         self.docroot: str = docroot
         if not os.path.exists(docroot):
-            os.makedirs(docroot, mode=0o700)
+            old_umask = os.umask(0)
+            try:
+                os.makedirs(docroot, mode=0o755)
+            finally:
+                os.umask(old_umask)
             for copy_file in ['404.html', '50x.html']:
                 src = os.path.join('/usr/share/nginx/html', copy_file)
                 if os.path.exists(src):
@@ -255,8 +259,12 @@ class NginxWebProxy(WebProxyInterface):
             os.path.dirname(context.getConfigVar('5gms_as.nginx', 'pid_path', '')),
             ]:
             if directory is not None and len(directory) > 0 and not os.path.isdir(directory):
-                os.makedirs(directory)
-    
+                old_umask = os.umask(0)
+                try:
+                    os.makedirs(directory, mode=0o755)
+                finally:
+                    os.umask(old_umask)
+
     __nginx = None
     __last_nginx_check = None
 


### PR DESCRIPTION
# Problem

(Spotted by @jordijoangimenez while doing end-to-end testing)

When running the AS as a system service the directories created for nginx to use can be created with permissions that allow only the root user to read/write. Since the default for nginx is to attempt to run part of nginx with effective UID of the "nobody" user this means that static files and disk caches can be denied access when that part of nginx tries to use them.

# Fix

This PR forces all directories created by the AS to appear on the file-system with read access for all users.

