### PR TITLE
Documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,31 @@
-# 5G-MAG Reference Tools: 5GMS Application Server
+# 5GMS Application Server
 
-This repository holds the 5GMS Application Server implementation for the 5G-MAG Reference Tools.
+This repository holds the 5GMS Application Server implementation for the 5G-MAG Reference Tools. 
+Note that currently this implementation only supports downlink media streaming.
 
 ## Introduction
 
-The 5GMS application server (AS) is a Network Function that forms part of the 5G Media Services framework as defined in
-ETSI TS 126.501.
+The 5GMS Application Server (AS) is a Network Function that forms part of the 5G Media Services framework as defined in ETSI TS 126.501.
+
+### 5GMS Downlink Application Server
+A 5GMS Downlink Application Server (5GMSd AS), which can be deployed in the 5G Core Network or in an External Data Network, provides 5G Downlink Media Streaming services to 5GMSd clients. This logical function embodies the data plane aspects of the 5GMSd System that deals with media content (for instance, a Content Delivery Network). The content is ingested from 5GMSd Application Providers at reference point M2d. Both push- and pull-based ingest methods are supported, based on HTTP. The content is distributed to 5GMSd clients at reference point M4d (after possible manipulation by the 5GMSd AS). Standard pull-based content retrieval protocols (e.g. DASH) are supported at this reference point.
+
+#### Specifications
+
+A list of specification related to 5G Downlink Media Streaming is available in the [Standards Wiki](https://github.com/5G-MAG/Standards/wiki/5G-Downlink-Media-Streaming-Architecture-(5GMSd):-Relevant-Specifications).
+
+#### About the implementation
 
 This implementation is comprised of a small Python daemon process which implements the 5GMS AS configuration service at interface M3,
 and which also manages an external HTTP(S) Web Server/Proxy daemon subprocess to ingest content (pull ingest only) at interface M2d
-and serve it to 5GMS Clients at interface M4d.
+and serve it to 5GMSd Clients at interface M4d.
 
-The AS is configured via the M3 interface, therefore you will need an appropriate M3 client to configure the AS. Such a client is
+The 5GMSd AS is configured via the M3 interface, therefore you will need an appropriate M3 client to configure the 5GMSd AS. Such a client is
 the [5GMS AF](https://github.com/5G-MAG/rt-5gms-application-function) (release v1.1.0 and above).
 
-The web server or reverse proxy functionality is provided by an external daemon. This 5GMS AS manages the external
+The web server or reverse proxy functionality is provided by an external daemon. This 5GMSd AS manages the external
 daemon by dynamically writing its configuration files and managing the daemon process lifecycle. At present the only
 daemon that can be controlled by the AS is nginx ([website](https://nginx.org/)).
-
-## Specifications
-
-A list of specification related to this repository is available [here](https://github.com/5G-MAG/Standards/wiki/5G-Media-Streaming-Architecture-(5GMS):-Relevant-Specifications).
 
 ## Install dependencies
 
@@ -126,7 +131,7 @@ Command line help can be obtained using the -h flag:
 
 Please note that the default configuration will require the application server to be run as the root user as it uses the privileged port 80 and stores logs and caches in root owned directories. If you wish to run this as an unprivileged user you will need to follow the instructions for creating and using an alternative configuration file. These instructions can be found in the [development documentation](docs/README.md#running-the-example-without-building).
 
-Once running you will need an M3 client, such as the [Reference Tools 5GMS AF](https://github.com/5G-MAG/rt-5gms-application-function), to manage the running AS. For standalone configuration for testing, see the "Testing without the Application Function" section of the [development documentation](docs/README.md#testing-without-the-application-function).
+Once running you will need an M3 client, such as the [5GMS AF](https://github.com/5G-MAG/rt-5gms-application-function), to manage the running AS. For standalone configuration for testing, see the "Testing without the Application Function" section of the [development documentation](docs/README.md#testing-without-the-application-function).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Note that currently this implementation only supports downlink media streaming.
 The 5GMS Application Server (AS) is a Network Function that forms part of the 5G Media Services framework as defined in ETSI TS 126.501.
 
 ### 5GMS Downlink Application Server
-A 5GMS Downlink Application Server (5GMSd AS), which can be deployed in the 5G Core Network or in an External Data Network, provides 5G Downlink Media Streaming services to 5GMSd clients. This logical function embodies the data plane aspects of the 5GMSd System that deals with media content (for instance, a Content Delivery Network). The content is ingested from 5GMSd Application Providers at reference point M2d. Both push- and pull-based ingest methods are supported, based on HTTP. The content is distributed to 5GMSd clients at reference point M4d (after possible manipulation by the 5GMSd AS). Standard pull-based content retrieval protocols (e.g. DASH) are supported at this reference point.
+A 5GMS Downlink Application Server (5GMSd AS), which can be deployed in the 5G Core Network or in an External Data Network, provides 5G Downlink Media Streaming services to 5GMSd Clients. This logical function embodies the data plane aspects of the 5GMSd System that deals with proxying media content (similar to a Content Delivery Network). The content is ingested from 5GMSd Application Providers at reference point M2d. Both push- and pull-based ingest methods are supported, based on HTTP. Ingested content is distributed to 5GMSd clients at reference point M4d (after possible manipulation by the 5GMSd AS). Standard pull-based content retrieval protocols (e.g. DASH) are supported at this reference point.
 
 #### Specifications
 


### PR DESCRIPTION
Rationale of the update:
- Keep the name of the repo generic (5GMS)
- Specify that currently this is only 5GMSd
- Introduction and implementation details are tailored to 5GMSd
- Download, building, installation, running are kept generic for 5GMS.