### PR TITLE
Documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Note that currently this implementation only supports downlink media streaming.
 The 5GMS Application Server (AS) is a Network Function that forms part of the 5G Media Services framework as defined in ETSI TS 126.501.
 
 ### 5GMS Downlink Application Server
-A 5GMS Downlink Application Server (5GMSd AS), which can be deployed in the 5G Core Network or in an External Data Network, provides 5G Downlink Media Streaming services to 5GMSd clients. This logical function embodies the data plane aspects of the 5GMSd System that deals with media content (for instance, a Content Delivery Network). The content is ingested from 5GMSd Application Providers at reference point M2d. Both push- and pull-based ingest methods are supported, based on HTTP. The content is distributed to 5GMSd clients at reference point M4d (after possible manipulation by the 5GMSd AS). Standard pull-based content retrieval protocols (e.g. DASH) are supported at this reference point.
+A 5GMS Downlink Application Server (5GMSd AS), which can be deployed in the 5G Core Network or in an External Data Network, provides 5G Downlink Media Streaming services to 5GMSd Clients. This logical function embodies the data plane aspects of the 5GMSd System that deals with proxying media content (similar to a Content Delivery Network). The content is ingested from 5GMSd Application Providers at reference point M2d. Both push- and pull-based ingest methods are supported, based on HTTP. Ingested content is distributed to 5GMSd clients at reference point M4d (after possible manipulation by the 5GMSd AS). Standard pull-based content retrieval protocols (e.g. DASH) are supported at this reference point.
 
 #### Specifications
 


### PR DESCRIPTION
Rationale of the update:
- Keep the name of the repo generic (5GMS)
- Specify that currently this is only 5GMSd
- Introduction and implementation details are tailored to 5GMSd
- Download, building, installation, running are kept generic for 5GMS.