### PR TITLE
Upstream redirects (Issue #70)

### DIFF
--- a/ATTRIBUTION_NOTICE
+++ b/ATTRIBUTION_NOTICE
@@ -16,6 +16,14 @@
   available at https://github.com/OpenAPITools/openapi-generator
   Licensed under Apache Software License v2.0 terms (https://www.apache.org/licenses/LICENSE-2.0)
 
+- openresty - Scalable Web Platform based on nginx
+  available at https://openresty.org/en/download.html
+  Parts licensed under various licenses:
+  - MIT License terms (https://github.com/urllib3/urllib3/blob/main/LICENSE.txt)  - Nginx, Inc. terms (https://trac.nginx.org/nginx/browser/nginx/docs/text/LICENSE)
+  - New BSD License terms (https://opensource.org/license/bsd-3-clause/)
+  - BSD License terms (https://opensource.org/license/bsd-2-clause/)
+  For full copyright and license terms see (https://openresty.org/download/Copyright-and-Licenses-for-3rd-Party-Open-Source-Projects.pdf)
+
 - nginx - HTTP server and proxy
   available from https://nginx.org/
   Licensed under Nginx, Inc. terms (https://trac.nginx.org/nginx/browser/nginx/docs/text/LICENSE)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A 5GMS Downlink Application Server (5GMSd AS), which can be deployed in the 5G C
 
 #### Specifications
 
-A list of specification related to 5G Downlink Media Streaming is available in the [Standards Wiki](https://github.com/5G-MAG/Standards/wiki/5G-Downlink-Media-Streaming-Architecture-(5GMSd):-Relevant-Specifications).
+A list of specifications related to 5G Downlink Media Streaming is available in the [Standards Wiki](https://github.com/5G-MAG/Standards/wiki/5G-Downlink-Media-Streaming-Architecture-(5GMSd):-Relevant-Specifications).
 
 #### About the implementation
 
@@ -25,7 +25,7 @@ the [5GMS AF](https://github.com/5G-MAG/rt-5gms-application-function) (release v
 
 The web server or reverse proxy functionality is provided by an external daemon. This 5GMSd AS manages the external
 daemon by dynamically writing its configuration files and managing the daemon process lifecycle. At present the only
-daemon that can be controlled by the AS is nginx ([website](https://nginx.org/)).
+daemon that can be controlled by the AS is Openresty (based on nginx) ([website](https://openresty.org/)).
 
 ## Install dependencies
 
@@ -111,11 +111,7 @@ Once [installed](#installing), the application server can be run using the follo
 Syntax: 5gms-application-server [-c <configuration-file>]
 ```
 
-Please note that the application server requires a suitable web proxy server to be installed. At present the only web proxy server that the application server can use is Nginx. This means you should install the nginx package on your distribution, for example:
-
-```bash
-apt -y install nginx
-```
+Please note that the application server requires a suitable web proxy server to be installed. At present the only web proxy server that the application server can use is Openresty. This means you should install the openresty package on your distribution, instruction to do so can be found on the [Openresty website](https://openresty.org/en/download.html) for [linux distributions](https://openresty.org/en/linux-packages.html) and [Microsoft Windows](https://openresty.org/en/download.html#windows).
 
 Most distributions will install Nginx to start on boot and some will even immediately start the Nginx service daemon when nginx is installed. A running default configuration of nginx will interfere with the operation of the application server by claiming TCP port 80 to listen on, thus denying the use of the TCP port to the application server. To avoid this it is best to disable and stop the nginx service, for example:
 

--- a/docs/example-application-server.conf
+++ b/docs/example-application-server.conf
@@ -203,3 +203,12 @@
 #
 # Default is /tmp/rt-5gms-as/5gms-as-nginx.pid
 #pid_path = %(root_temp)s/5gms-as-nginx.pid
+
+# resolvers - DNS resolvers for NGinx
+#
+# This is a space separated list of DNS resolvers that Nginx should use.
+#
+# See: https://nginx.org/en/docs/ngx_http_core_module.html#resolver
+#
+# Default is 127.0.0.53 (use local systemd-resolved)
+#resolvers = 127.0.0.53

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ readme = "README.md"
 where = ["src", "tests"]
 
 [tool.setuptools.package-data]
-"rt_5gms_as.proxies" = ["*.tmpl"]
+"rt_5gms_as.proxies" = ["*.tmpl", "*.lua"]
 
 [tool.setuptools.data-files]
 'share/doc/rt-5gms-application-server' = ['docs/*', 'ATTRIBUTION_NOTICE']

--- a/src/rt_5gms_as/context.py
+++ b/src/rt_5gms_as/context.py
@@ -63,6 +63,7 @@ fastcgi_temp = %(root_temp)s/fastcgi-tmp
 uwsgi_temp = %(root_temp)s/uwsgi-tmp
 scgi_temp = %(root_temp)s/scgi-tmp
 pid_path = %(root_temp)s/rt-5gms-as-nginx.pid
+resolvers = 127.0.0.53
 '''
 
 class Context(object):

--- a/src/rt_5gms_as/context.py
+++ b/src/rt_5gms_as/context.py
@@ -398,7 +398,7 @@ class Context(object):
                 try:
                     os.makedirs(directory, mode=0o755)
                 finally:
-                    os.umake(old_umask)
+                    os.umask(old_umask)
         # get logging level from the configuration file
         logging_levels = {
                 'debug': logging.DEBUG,

--- a/src/rt_5gms_as/proxies/dynamicredirect.lua
+++ b/src/rt_5gms_as/proxies/dynamicredirect.lua
@@ -1,0 +1,57 @@
+local dynamicredirect = {}
+
+local cjson = require "cjson"
+local ngx = require "ngx"
+
+local function uuid()
+    -- Implement UUID v4 format (random)
+    return string.format("%0.4x%0.4x-%0.4x-4%0.3x-%0.4x-%0.4x%0.4x%0.4x", math.random(0,0xffff), math.random(0,0xffff), math.random(0,0xffff), math.random(0,0xfff), math.random(0,0xffff), math.random(0,0xffff), math.random(0,0xffff), math.random(0,0xffff))
+end
+
+local function dynamicredirect_get(provisioning_session_prefix, upstream_prefix)
+    local redir_map = ngx.shared.dynredirmap
+    local _
+    local key
+    for _,key in ipairs(redir_map:get_keys(0)) do
+        value = redir_map:get(key)
+        if key:sub(0,provisioning_session_prefix:len()) == provisioning_session_prefix and value == upstream_prefix then
+            dynamicredirect.set(key, value) -- Renew expiry time
+            return key
+        end
+    end
+    local redir_prefix = provisioning_session_prefix.."redir-"..uuid().."/"
+    dynamicredirect.set(redir_prefix, upstream_prefix)
+    return redir_prefix
+end
+dynamicredirect.get = dynamicredirect_get
+
+local function dynamicredirect_set(m4_prefix, upstream_prefix)
+    ngx.shared.dynredirmap:set(m4_prefix, upstream_prefix, 120)
+end
+dynamicredirect.set = dynamicredirect_set
+
+local function dynamicredirect_mapUrl(provisioning_session_prefix, default_proxy, url_path)
+    local redir_map = ngx.shared.dynredirmap
+    local full_path = provisioning_session_prefix..(url_path:sub(2))
+    local now = ngx.time
+    redir_map:flush_expired(0)
+    -- ngx.log(ngx.DEBUG,"mapUrl(",provisioning_session_prefix,", ",default_proxy,", ",url_path,")")
+    local map_keys = redir_map:get_keys(0)
+    local _
+    local k
+    for _,k in ipairs(map_keys) do
+        -- ngx.log(ngx.DEBUG,"k = ",k)
+        -- ngx.log(ngx.DEBUG," == ",full_path:sub(0,k:len()),"?")
+        if k == full_path:sub(0,k:len()) then
+            local v = redir_map:get(k)
+            dynamicredirect.set(k,v) -- Renew expiry time
+            return v,full_path:sub(k:len())
+        end
+    end
+    return default_proxy,url_path
+end
+dynamicredirect.mapUrl = dynamicredirect_mapUrl
+
+return dynamicredirect
+
+-- vim:ts=8:sts=4:sw=4:expandtab:

--- a/src/rt_5gms_as/proxies/nginx.conf.tmpl
+++ b/src/rt_5gms_as/proxies/nginx.conf.tmpl
@@ -45,11 +45,25 @@ http {{
   fastcgi_temp_path {fastcgi_temp_path};
   uwsgi_temp_path {uwsgi_temp_path};
   scgi_temp_path {scgi_temp_path};
+  lua_package_path "{scriptdir}/?.lua;;";
+  lua_shared_dict dynredirmap 10m;
+  resolver {resolvers};
 
   include             /etc/nginx/mime.types;
   default_type        application/octet-stream;
 
   server_names_hash_bucket_size 128; # this seems to be required for some vhosts
+
+  init_by_lua_block {{
+    dynredir = require "dynamicredirect"
+
+    math.randomseed(os.time())
+
+    function re_escape(s)
+      local ret = s:gsub("([]*^[%%.()])", "%%%1")
+      return ret
+    end
+  }}
 
 {server_configs}
 

--- a/src/rt_5gms_as/server.py
+++ b/src/rt_5gms_as/server.py
@@ -61,6 +61,7 @@ class M3Server:
             raise ProblemException(status_code=405, title='ContentHostingConfiguration Already Exists', instance=request.url.path)
         # Add the configuration to the current context
         self.__context.appLog().info("Adding content hosting configuration %s..."%(provisioningSessionId))
+        self.__context.appLog().debug("provisioning_session_id = %s, chc = %r", provisioningSessionId, content_hosting_configuration)
         try:
             self.__context.addContentHostingConfiguration(provisioningSessionId, content_hosting_configuration)
         except Context.ConfigError as err:

--- a/systemd/5gms-application-server.service
+++ b/systemd/5gms-application-server.service
@@ -20,6 +20,7 @@ Conflicts=nginx.service
 
 [Service]
 Type=simple
+Environment="PATH=/usr/local/openresty/nginx/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin:/snap/bin"
 EnvironmentFile=-/etc/default/rt-5gms-as
 ExecStart=/usr/local/bin/5gms-application-server
 ExecReload=kill -HUP $MAINPID


### PR DESCRIPTION
This adds dynamic tracking and rewriting of redirects passing through the reverse proxy.

Closes #70 

This changes the dependency requirement of the AS from the simple nginx package to Openresty. This is due to the use of the Lua language to manage the redirects tracking. Please see the README.md in the top directory of the repository for links to instructions for installing Openresty.