### PR TITLE
Bug-fix: Use SNI with media origin

### DIFF
--- a/src/rt_5gms_as/proxies/nginx.conf.tmpl
+++ b/src/rt_5gms_as/proxies/nginx.conf.tmpl
@@ -48,6 +48,7 @@ http {{
   lua_package_path "{scriptdir}/?.lua;;";
   lua_shared_dict dynredirmap 10m;
   resolver {resolvers};
+  proxy_ssl_server_name on;
 
   include             /etc/nginx/mime.types;
   default_type        application/octet-stream;


### PR DESCRIPTION
# Description of issue

It was noticed recently that the Azure sample media streams we have been using on rt.5g-mag.com are now returning a 403 forbidden.

The streams were changed to similar streams from https://rdmedia.bbc.co.uk/ however this then generated a 502 error. This is due to an unknown SSL handshake failure.

# Remedy

The servers being used by rdmedia.bbc.co.uk are general CDN servers, so it was postulated that the "rdmedia.bbc.co.uk" name was not being passed in the SNI allowing the CDN node to determine which server it is being a reverse proxy of. A quick test with OpenSSL tools confirmed this.

The solution is to add `proxy_ssl_server_name on;` to the nginx http configuration to make it send an SNI when proxying requests.

With the fix in place on the Linode instance we get a normal response from rdmedia.bbc.co.uk.