### PR TITLE
Bug-fix: Handle changes to OpenAPI models when pydantic v2 is installed

### DIFF
--- a/src/rt_5gms_as/proxies/nginx.py
+++ b/src/rt_5gms_as/proxies/nginx.py
@@ -365,6 +365,8 @@ class NginxWebProxy(WebProxyInterface):
             if downstream_origin is None:
                 self.log.error("Configuration must have an ingestConfiguration.baseURL")
                 return False
+            if not isinstance(downstream_origin, str):
+                downstream_origin = str(downstream_origin)
             if downstream_origin[-1] == '/':
                 downstream_origin = downstream_origin[:-1]
             for dc in i.distribution_configurations:
@@ -378,7 +380,7 @@ class NginxWebProxy(WebProxyInterface):
                     dsk = (dc.domain_name_alias, certificate_filename is not None)
                     if dsk not in server_configs:
                         server_configs[dsk] = NginxServerConfig(self._context, {dc.domain_name_alias}, proxy_cache_path is not None, certificate_filename)
-                base_url = urlparse(dc.base_url)
+                base_url = urlparse(str(dc.base_url))
                 m4d_path_prefix = base_url.path
                 if m4d_path_prefix[0] != '/':
                     m4d_path_prefix = '/' + m4d_path_prefix


### PR DESCRIPTION
This fixes the issue where the AS would abort when it was configured because the object to JSON string conversion function no longer takes json.dumps() keyword arguments in pydantic v2.

The fix will detect if the pydantic v2 `model_dump()` method is available on the object and adapt the way in which it generates the JSON string appropriately.

This also fixes another issue with pydantic v2 now using a `Url` class to model URL properties instead of a string.

Closes #81 