### PR TITLE
Feature: TS 26.512 v17.7.0 uplift

### DIFF
--- a/src/rt_5gms_as/server.py
+++ b/src/rt_5gms_as/server.py
@@ -155,7 +155,7 @@ class M3Server:
             else:
                 result = await self.__context.webProxy().purgeUsingRegex(provisioningSessionId, pattern)
         except regex.error as err:
-            raise ProblemException(title='Unprocessable Entity', status_code=422, instance=request.url.path, detail='Bad regex: '+str(err), invalid_params=[{'param': 'pattern', 'reason': str(err)}])
+            raise ProblemException(title='Unprocessable Entity', status_code=400, instance=request.url.path, detail='Bad regex: '+str(err), invalid_params=[{'param': 'pattern', 'reason': str(err)}])
         except WebProxyError as err:
             raise ProblemException(title='Internal Error', status_code=500, instance=request.url.path, detail='Regex failed to compile: '+str(err))
         except Exception as err:


### PR DESCRIPTION
To keep the AS in line with the v17.7.0 changes there is a change of result code, from 422 to 400, for when the purge regex will not parse. This is not strictly part of TS 26.512 v17.7.0 as the M3 interface is not defined until the Rel-18 spec.

This also brings the version of rt-common-shared being used up to date.