### PR TITLE
Bug fixes: Find mime.types file location and automatically find Openresty path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ backend-path = ["build_scripts"]
 
 [project]
 name = "rt-5gms-application-server"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
     'urllib3 >= 1.25.3',
     'python-dateutil',

--- a/src/rt_5gms_as/app.py
+++ b/src/rt_5gms_as/app.py
@@ -22,6 +22,18 @@ Reference Tools: 5GMS Application Server
 
 This NF provides the configuration interface for an external web proxy daemon.
 '''
+import os
+import os.path
+
+# Promote known Openresty locations to the head of the PATH environment variable
+openresty_bin_dir=None
+for d in ['/usr/local/openresty/nginx/sbin']:
+    if os.path.isdir(d):
+        openresty_bin_dir=d
+        break
+if openresty_bin_dir is not None:
+    os.environ['PATH'] = ':'.join([openresty_bin_dir] + [p for p in os.environ['PATH'].split(':') if p != openresty_bin_dir])
+
 import argparse
 import asyncio
 import hypercorn

--- a/src/rt_5gms_as/proxies/nginx.conf.tmpl
+++ b/src/rt_5gms_as/proxies/nginx.conf.tmpl
@@ -19,7 +19,7 @@ error_log	{error_log_path};
 pid		{pid_path};
 worker_rlimit_nofile 8192;
 
-include /usr/share/nginx/modules/*.conf;
+{nginx_module_includes}
 
 events {{
   worker_connections 4096;
@@ -50,7 +50,7 @@ http {{
   resolver {resolvers};
   proxy_ssl_server_name on;
 
-  include             /etc/nginx/mime.types;
+  include             {mime_types_file};
   default_type        application/octet-stream;
 
   server_names_hash_bucket_size 128; # this seems to be required for some vhosts

--- a/src/rt_5gms_as/proxies/nginx.py
+++ b/src/rt_5gms_as/proxies/nginx.py
@@ -349,6 +349,12 @@ class NginxWebProxy(WebProxyInterface):
         fastcgi_temp_path = self._context.getConfigVar('5gms_as.nginx','fastcgi_temp')
         uwsgi_temp_path = self._context.getConfigVar('5gms_as.nginx','uwsgi_temp')
         scgi_temp_path = self._context.getConfigVar('5gms_as.nginx','scgi_temp')
+        nginx_module_includes = '\n'.join([f'include\t{p}/*.conf;' for p in ['/usr/share/nginx/modules'] if os.path.isdir(p)])
+        mime_types_file = 'mime.types'
+        for mtf in ['/usr/local/openresty/nginx/conf/mime.types', '/etc/nginx/mime.types']:
+            if os.path.isfile(mtf):
+                mime_types_file = mtf
+                break
         scriptdir = os.path.dirname(os.path.abspath(__file__))
         # Create caching directives if we have a cache dir configured
         proxy_cache_path_directive = ''


### PR DESCRIPTION
This PR includes some minor bug fixes for #83 and #89.

Find mime.types file (#83):
- The code will now look in known locations first for the Openresty `mime.types` file and then for the default nginx `mime.types` file and use the found `mime.types` in the nginx configuration.
   - Currently checks `/usr/local/openresty/nginx/conf/mime.types` and `/etc/nginx/mime.types`.
   -  These paths work for RedHat and Ubuntu linux flavours, if we find other distributions with different paths these can be added later.
- The modules path for nginx is only included in the nginx configuration if it exists at the known location.
   -  Currently this checks for `/usr/share/nginx/modules` being present (Openresty automatically includes its own modules so doesn't need this extra include in the nginx configuration).

Automatically find Openresty path (#89):
- As the python app starts it looks for known Openresty `nginx/sbin` directories and if found prepends it to the `PATH` environment variable for the AS environment.
   - Currently checks for `/usr/local/openresty/nginx/sbin`.
   - This path works for RedHat and Ubuntu linux flavours, if we find other distributions with different paths these can be added later.

Fixes #83 
Fixes #89 