### PR TITLE
Uplift to 3GPP TS26.512 v17.10.0 (SA#106)

### DIFF
--- a/build_scripts/generate_5gms_as_openapi
+++ b/build_scripts/generate_5gms_as_openapi
@@ -22,8 +22,8 @@ scriptdir=`dirname "$0"`
 scriptdir=`cd "$scriptdir"; pwd`
 
 rt_5gms_as_dir=`cd "${scriptdir}/../src/rt_5gms_as"; pwd`
-common_scripts_dir=`cd "${scriptdir}/../external/rt-common-shared/5gms/scripts"; pwd`
-fiveg_apis_overrides=`cd "$common_scripts_dir/../5G_APIs-overrides"; pwd`
+common_scripts_dir=`cd "${scriptdir}/../external/rt-common-shared/open5gs-tools/scripts"; pwd`
+fiveg_apis_overrides=`cd "$common_scripts_dir/../5G_APIs-overrides"; pwd`':'`cd "${scriptdir}/../external/rt-common-shared/5gms/5G_APIs-overrides"; pwd`
 
 # Command line defaults
 default_api='TS26512_M1_ContentHostingProvisioning M3_merged'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ backend-path = ["build_scripts"]
 
 [project]
 name = "rt-5gms-application-server"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
     'urllib3 >= 1.25.3',
     'python-dateutil',


### PR DESCRIPTION
Closes #98

This updates the Application Server to use the latest 3GPP-Rel17 branch of the 5G-MAG/rt-common-shared repository when creating the python bindings used on the M3 interface.